### PR TITLE
Implement proposed change to IG profile page layout + profile-patient

### DIFF
--- a/framework/templates/template-profile.html
+++ b/framework/templates/template-profile.html
@@ -212,15 +212,7 @@
     </div>
   </div>
   <p>&#160;</p>
-  <p>Other representations of profile: <a href="{{[id]}}.sch">Schematron</a>
-  </p>
-  <a name="tx"> </a>
-  <h3 id="tx">Terminology Bindings</h3>
-  {%include StructureDefinition-{{[id]}}-tx.xhtml%}
-
-  <a name="inv"> </a>
-  <h3 id="inv">Constraints</h3>
-  {%include StructureDefinition-{{[id]}}-inv.xhtml%}
+  <p>Other representations of profile: <a href="{{[id]}}.sch">Schematron</a></p>
 
   {% assign notes = site.data.pages[page.path].notes %}
   {% if notes != null %}
@@ -237,6 +229,14 @@
   </div>
   {% endif %}
   {% endif %}
+
+  <a name="tx"> </a>
+  <h3 id="tx">Terminology Bindings</h3>
+  {%include StructureDefinition-{{[id]}}-tx.xhtml%}
+
+  <a name="inv"> </a>
+  <h3 id="inv">Constraints</h3>
+  {%include StructureDefinition-{{[id]}}-inv.xhtml%}
 
 </div>
 {% assign includetabscripts = 'true' %}

--- a/src/pagecontent/profile-patient-intro.md
+++ b/src/pagecontent/profile-patient-intro.md
@@ -16,12 +16,10 @@ Key differences from [USCoreR4 Patient](https://build.fhir.org/ig/HL7/US-Core-R4
 
 ## Mandatory Data Elements
 All elements or attributes defined in FHIR have cardinality as part of their definition - a minimum number of required appearances and a maximum number.
-Most elements have a minimum cardinality of 0, which means that they may be missing from a resource when it is exchanged between systems. 
 
-Canadian Core Patient Profile defines following elements with minimum cardinality of 1 or as mandatory (i.e data MUST be present). 
+Most elements in FHIR specification have a minimum cardinality of 0, which means that they may be missing from a resource when it is exchanged between systems. 
 
-**Each Patient must have:**
-1. a patient name
+In this Canadian Core Patient Profile all elements are optional, i.e., there is no element with a minimum cardinality of 1. However, some optional elements (e.g., identifier) have required components that MUST be present if that optional element is provided.
 
 ### Data Absent Reason
 In situations where the minimum cardinality of an element or attribute is 1 and information is missing and the Responder knows the precise reason for the absence of data, Responders SHALL send the reason for the missing information using values (such as [NullFlavor](https://www.hl7.org/fhir/extension-iso21090-nullflavor.html)) from the value set where they exist or using the [DataAbsentReason](http://hl7.org/fhir/StructureDefinition/data-absent-reason) extension.

--- a/src/pagecontent/profile-patient-notes.md
+++ b/src/pagecontent/profile-patient-notes.md
@@ -62,7 +62,24 @@ URIs used with this identifier type:
 ### Jurisdictional Health Number (JHN)
 This patient identifier type identifies a number issued in Canada to let a patient to be recognized for services and stay connected to related support programs.
 
-URIs used with this identifier type:
+Following URIs are registered to identify health numbers for provinces and territories:
+* Alberta - https://fhir.infoway-inforoute.ca/NamingSystem/ca-ab-patient-healthcare-id
+* British Columbia - https://fhir.infoway-inforoute.ca/NamingSystem/ca-bc-patient-healthcare-id
+* Manitoba - https://fhir.infoway-inforoute.ca/NamingSystem/ca-mb-patient-healthcare-id
+* New Brunswick - https://fhir.infoway-inforoute.ca/NamingSystem/ca-nb-patient-healthcare-id
+* Newfoundland and Labrador - https://fhir.infoway-inforoute.ca/NamingSystem/ca-nl-patient-healthcare-id
+* Northwest Terrirories - https://fhir.infoway-inforoute.ca/NamingSystem/ca-nt-patient-healthcare-id
+* Nova Scotia - https://fhir.infoway-inforoute.ca/NamingSystem/ca-ns-patient-healthcare-id
+* Nunavut - https://fhir.infoway-inforoute.ca/NamingSystem/ca-nu-patient-healthcare-id
+* Ontario - https://fhir.infoway-inforoute.ca/NamingSystem/ca-on-patient-hcn
+* Prince Edward Island - https://fhir.infoway-inforoute.ca/NamingSystem/ca-pe-patient-healthcare-id
+* Quebec - https://fhir.infoway-inforoute.ca/NamingSystem/ca-qc-patient-healthcare-id
+* Saskatchewan - https://fhir.infoway-inforoute.ca/NamingSystem/ca-sk-patient-healthcare-id
+* Yukon - https://fhir.infoway-inforoute.ca/NamingSystem/ca-yt-patient-healthcare-id
+
+The full list is in [Canadian URI Registry](https://simplifier.net/canadianuriregistry/~resources?category=NamingSystem)
+
+Other URIs used with this identifier type:
 * Canada Veteran's Affairs health card number - https://fhir.infoway-inforoute.ca/NamingSystem/ca-veterans-affairs-health-id
 * Canada Correctional Service health card number - https://fhir.infoway-inforoute.ca/NamingSystem/ca-correctional-service-health-id
 * Canada Royal Canadian Mounted Police (RCMP) health card number - https://fhir.infoway-inforoute.ca/NamingSystem/ca-royal-mounted-police-health-id

--- a/src/resources/structuredefinition-profile-patient.json
+++ b/src/resources/structuredefinition-profile-patient.json
@@ -1,338 +1,338 @@
 {
-	"resourceType": "StructureDefinition",
-	"id": "profile-patient",
-	"url": "http://hl7.org/fhir/ca/core/StructureDefinition/profile-patient",
-	"version": "0.1.0",
-	"name": "PatientProfile",
-	"title": "Patient Profile",
-	"status": "draft",
-	"date": "2020-01-13",
-	"publisher": "Canada Health Infoway",
-	"description": "Proposed constraints and extensions on the Patient Resource",
-	"kind": "resource",
-	"abstract": false,
-	"type": "Patient",
-	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
-	"derivation": "constraint",
-	"differential": {
-		"element": [
-			{
-				"id": "Patient",
-				"path": "Patient",
-				"short": "Patient Profile",
-				"definition": "The Patient Profile is based upon the core FHIR Patient Resource",
-				"mustSupport": true,
-				"isModifier": false
-			}, {
-				"id": "Patient.extension",
-				"path": "Patient.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"rules": "open"
-				}
-			}, {
-				"id": "Patient.extension:birthsex",
-				"path": "Patient.extension",
-				"sliceName": "birthsex",
-				"short": "Extension: Sex at Birth",
-				"definition": "A code classifying the person's sex assigned at birth  as specified by the [TODO: assigning authority]. This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9)",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/ca/core/StructureDefinition/ext-patientbirthsex"
-						]
-					}
-				],
-				"mustSupport": false
-			}, {
-				"id": "Patient.extension:ethnicity",
-				"path": "Patient.extension",
-				"sliceName": "ethnicity",
-				"short": "Extension: ethnicity extension",
-				"definition": "A code classifying the person's ethnic group or ethnicity as the category of people who identify with each other, usually on the basis of a presumed common genealogy or ancestry or on other similarities.",
-				"comment": "This attribute is based on the belief of the person or the person reporting the attribute, not on any formal analysis of genetic, geneological or historical relationships as these would need to be captured as observations.",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/ca/core/StructureDefinition/ext-ethnicity"
-						]
-					}
-				],
-				"mustSupport": false,
-				"isModifier": false,
-				"mapping": [
-					{
-						"identity": "HL7v2",
-						"map": "PID.22 [Ethnic Group]",
-						"comment": "This field further defines the patient's ancestry.  Refer to User-defined Table 0189 - Ethnic Group in Chapter 2C, Code Tables, for suggested values."
-					}, {
-						"identity": "rim",
-						"map": "Person.ethnicGroupCode",
-						"comment": "A code classifying the person into a named category of humans sharing a common real or presumed heritage"
-					}, {
-						"identity": "CDA",
-						"map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:ethnicGroupCode",
-						"comment": "This CDA R2 SDTC ethnicGroupCode extension is used to record additional ethnicity groups for the recordTarget or subjectPerson"
-					}
-				]
-			}, {
-				"id": "Patient.identifier",
-				"path": "Patient.identifier",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "pattern",
-							"path": "type"
-						}
-					],
-					"rules": "open"
-				},
-				"min": 0
-			}, {
-				"id": "Patient.identifier.type",
-				"path": "Patient.identifier.type",
-				"min": 1,
-				"example": [
-					{
-						"label": "Pattern",
-						"valueCodeableConcept": {
-							"coding": [
-								{
-									"system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-									"code": "MR"
-								}
-							]
-						}
-					}
-				],
-				"mustSupport": true
-			}, {
-				"id": "Patient.identifier.system",
-				"path": "Patient.identifier.system",
-				"min": 1,
-				"mustSupport": true,
-				"isModifier": false
-			}, {
-				"id": "Patient.identifier.value",
-				"path": "Patient.identifier.value",
-				"short": "The value that is unique within the system.",
-				"min": 1,
-				"mustSupport": true,
-				"isModifier": false
-			}, {
-				"id": "Patient.identifier:PPN",
-				"path": "Patient.identifier",
-				"sliceName": "PPN",
-				"short": "Canada Passport Number",
-				"mustSupport": false
-			}, {
-				"id": "Patient.identifier:PPN.type",
-				"path": "Patient.identifier.type",
-				"short": "Passport number identifier type",
-				"min": 1,
-				"max": "1",
-				"fixedCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-							"code": "PPN"
-						}
-					]
-				}
-			}, {
-				"id": "Patient.identifier:PPN.system",
-				"path": "Patient.identifier.system",
-				"short": "A Canadian passport number Naming System from the Canadian URI Registry",
-				"min": 1,
-				"max": "1",
-				"fixedUri": "https://fhir.infoway-inforoute.ca/NamingSystem/ca-passport-number"
-			}, {
-				"id": "Patient.identifier:PPN.value",
-				"path": "Patient.identifier.value",
-				"short": "A Canadian passport number",
-				"min": 1,
-				"max": "1"
-			}, {
-				"id": "Patient.identifier:JPID",
-				"path": "Patient.identifier",
-				"sliceName": "JPID",
-				"short": "Jurisdictional Person Identification",
-				"definition": "Federal patient and person identifiers used by all jurisdictions across Canada",
-				"mustSupport": false
-			}, {
-				"id": "Patient.identifier:JPID.type",
-				"path": "Patient.identifier.type",
-				"short": "Jurisdictional Person Identification",
-				"min": 1,
-				"max": "1",
-				"fixedCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-							"code": "JPID"
-						}
-					]
-				}
-			}, {
-				"id": "Patient.identifier:JPID.system",
-				"path": "Patient.identifier.system",
-				"short": "Jurisdictional Person identification Naming System from the Canadian URI Registry",
-				"min": 1,
-				"max": "1"
-			}, {
-				"id": "Patient.identifier:JPID.value",
-				"path": "Patient.identifier.value",
-				"short": "Jurisdictional Person identification number",
-				"min": 1,
-				"max": "1"
-			}, {
-				"id": "Patient.identifier:JHN",
-				"path": "Patient.identifier",
-				"sliceName": "JHN",
-				"short": "Jurisdictional Health Number",
-				"definition": "Federal patient and person health numbers used by all jurisdictions across Canada"
-			}, {
-				"id": "Patient.identifier:JHN.extension",
-				"path": "Patient.identifier.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"rules": "open"
-				}
-			}, {
-				"id": "Patient.identifier:JHN.extension:versionCode",
-				"path": "Patient.identifier.extension",
-				"sliceName": "versionCode",
-				"short": "Health Number Version Code",
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/ca/core/StructureDefinition/ext-identifierversion"
-						]
-					}
-				]
-			}, {
-				"id": "Patient.identifier:JHN.type",
-				"path": "Patient.identifier.type",
-				"min": 1,
-				"fixedCodeableConcept": {
-					"coding": [
-						{
-							"system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-							"code": "JHN"
-						}
-					]
-				},
-				"mustSupport": true
-			}, {
-				"id": "Patient.identifier:JHN.system",
-				"path": "Patient.identifier.system",
-				"short": "A Health Number Naming System from the Canadian URI Registry",
-				"min": 1
-			}, {
-				"id": "Patient.identifier:JHN.value",
-				"path": "Patient.identifier.value",
-				"min": 1
-			}, {
-				"id": "Patient.name",
-				"path": "Patient.name",
-				"min": 0,
-				"constraint": [
-					{
-						"key": "ca-core-name",
-						"severity": "error",
-						"human": "Patient.name.given  or Patient.name.family or both SHALL be present",
-						"expression": "family.exists() or given.exists()",
-						"xpath": "f:given or f:family"
-					}
-				],
-				"mustSupport": true
-			}, {
-				"id": "Patient.name.family",
-				"path": "Patient.name.family"
-			}, {
-				"id": "Patient.name.given",
-				"path": "Patient.name.given"
-			}, {
-				"id": "Patient.telecom",
-				"path": "Patient.telecom",
-				"mustSupport": true
-			}, {
-				"id": "Patient.telecom.system",
-				"path": "Patient.telecom.system",
-				"min": 1
-			}, {
-				"id": "Patient.telecom.value",
-				"path": "Patient.telecom.value",
-				"min": 1
-			}, {
-				"id": "Patient.birthDate",
-				"path": "Patient.birthDate",
-				"mustSupport": true
-			}, {
-				"id": "Patient.address",
-				"path": "Patient.address"
-			}, {
-				"id": "Patient.address.extension",
-				"path": "Patient.address.extension",
-				"slicing": {
-					"discriminator": [
-						{
-							"type": "value",
-							"path": "url"
-						}
-					],
-					"rules": "open"
-				}
-			}, {
-				"id": "Patient.address.extension:preferred",
-				"path": "Patient.address.extension",
-				"sliceName": "preferred",
-				"short": "HL7 Preferred Address Flag extension",
-				"definition": "Flag denoting whether parent address item is preferred",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/StructureDefinition/iso21090-preferred"
-						]
-					}
-				]
-			}, {
-				"id": "Patient.address.extension:no-fixed-address",
-				"path": "Patient.address.extension",
-				"sliceName": "noFixedAddress",
-				"short": "No Fixed Address indicator",
-				"definition": "Flag indicating that there is an assertion that there is no fixed address",
-				"min": 0,
-				"max": "1",
-				"type": [
-					{
-						"code": "Extension",
-						"profile": [
-							"http://hl7.org/fhir/ca/core/StructureDefinition/ext-nofixedaddress"
-						]
-					}
-				]
-			}
-		]
-	}
+  "resourceType": "StructureDefinition",
+  "id": "profile-patient",
+  "url": "http://hl7.org/fhir/ca/core/StructureDefinition/profile-patient",
+  "version": "0.1.0",
+  "name": "PatientProfile",
+  "title": "Patient Profile",
+  "status": "draft",
+  "date": "2020-01-13",
+  "publisher": "Canada Health Infoway",
+  "description": "Proposed constraints and extensions on the Patient Resource",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Patient",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Patient",
+        "path": "Patient",
+        "short": "Patient Profile",
+        "definition": "The Patient Profile is based upon the core FHIR Patient Resource",
+        "mustSupport": true,
+        "isModifier": false
+      }, {
+        "id": "Patient.extension",
+        "path": "Patient.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "rules": "open"
+        }
+      }, {
+        "id": "Patient.extension:birthsex",
+        "path": "Patient.extension",
+        "sliceName": "birthsex",
+        "short": "Extension: Sex at Birth",
+        "definition": "A code classifying the person's sex assigned at birth  as specified by the [TODO: assigning authority]. This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9)",
+        "min": 0,
+        "max": "1",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://hl7.org/fhir/ca/core/StructureDefinition/ext-patientbirthsex"
+            ]
+          }
+        ],
+        "mustSupport": false
+      }, {
+        "id": "Patient.extension:ethnicity",
+        "path": "Patient.extension",
+        "sliceName": "ethnicity",
+        "short": "Extension: ethnicity extension",
+        "definition": "A code classifying the person's ethnic group or ethnicity as the category of people who identify with each other, usually on the basis of a presumed common genealogy or ancestry or on other similarities.",
+        "comment": "This attribute is based on the belief of the person or the person reporting the attribute, not on any formal analysis of genetic, geneological or historical relationships as these would need to be captured as observations.",
+        "min": 0,
+        "max": "1",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://hl7.org/fhir/ca/core/StructureDefinition/ext-ethnicity"
+            ]
+          }
+        ],
+        "mustSupport": false,
+        "isModifier": false,
+        "mapping": [
+          {
+            "identity": "HL7v2",
+            "map": "PID.22 [Ethnic Group]",
+            "comment": "This field further defines the patient's ancestry.  Refer to User-defined Table 0189 - Ethnic Group in Chapter 2C, Code Tables, for suggested values."
+          }, {
+            "identity": "rim",
+            "map": "Person.ethnicGroupCode",
+            "comment": "A code classifying the person into a named category of humans sharing a common real or presumed heritage"
+          }, {
+            "identity": "CDA",
+            "map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:ethnicGroupCode",
+            "comment": "This CDA R2 SDTC ethnicGroupCode extension is used to record additional ethnicity groups for the recordTarget or subjectPerson"
+          }
+        ]
+      }, {
+        "id": "Patient.identifier",
+        "path": "Patient.identifier",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "pattern",
+              "path": "type"
+            }
+          ],
+          "rules": "open"
+        },
+        "min": 0
+      }, {
+        "id": "Patient.identifier.type",
+        "path": "Patient.identifier.type",
+        "min": 1,
+        "example": [
+          {
+            "label": "Pattern",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "MR"
+                }
+              ]
+            }
+          }
+        ],
+        "mustSupport": true
+      }, {
+        "id": "Patient.identifier.system",
+        "path": "Patient.identifier.system",
+        "min": 1,
+        "mustSupport": true,
+        "isModifier": false
+      }, {
+        "id": "Patient.identifier.value",
+        "path": "Patient.identifier.value",
+        "short": "The value that is unique within the system.",
+        "min": 1,
+        "mustSupport": true,
+        "isModifier": false
+      }, {
+        "id": "Patient.identifier:PPN",
+        "path": "Patient.identifier",
+        "sliceName": "PPN",
+        "short": "Canada Passport Number",
+        "mustSupport": false
+      }, {
+        "id": "Patient.identifier:PPN.type",
+        "path": "Patient.identifier.type",
+        "short": "Passport number identifier type",
+        "min": 1,
+        "max": "1",
+        "fixedCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+              "code": "PPN"
+            }
+          ]
+        }
+      }, {
+        "id": "Patient.identifier:PPN.system",
+        "path": "Patient.identifier.system",
+        "short": "A Canadian passport number Naming System from the Canadian URI Registry",
+        "min": 1,
+        "max": "1",
+        "fixedUri": "https://fhir.infoway-inforoute.ca/NamingSystem/ca-passport-number"
+      }, {
+        "id": "Patient.identifier:PPN.value",
+        "path": "Patient.identifier.value",
+        "short": "A Canadian passport number",
+        "min": 1,
+        "max": "1"
+      }, {
+        "id": "Patient.identifier:JPID",
+        "path": "Patient.identifier",
+        "sliceName": "JPID",
+        "short": "Jurisdictional Person Identification",
+        "definition": "Federal patient and person identifiers used by all jurisdictions across Canada",
+        "mustSupport": false
+      }, {
+        "id": "Patient.identifier:JPID.type",
+        "path": "Patient.identifier.type",
+        "short": "Jurisdictional Person Identification",
+        "min": 1,
+        "max": "1",
+        "fixedCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+              "code": "JPID"
+            }
+          ]
+        }
+      }, {
+        "id": "Patient.identifier:JPID.system",
+        "path": "Patient.identifier.system",
+        "short": "Jurisdictional Person identification Naming System from the Canadian URI Registry",
+        "min": 1,
+        "max": "1"
+      }, {
+        "id": "Patient.identifier:JPID.value",
+        "path": "Patient.identifier.value",
+        "short": "Jurisdictional Person identification number",
+        "min": 1,
+        "max": "1"
+      }, {
+        "id": "Patient.identifier:JHN",
+        "path": "Patient.identifier",
+        "sliceName": "JHN",
+        "short": "Jurisdictional Health Number",
+        "definition": "Federal patient and person health numbers used by all jurisdictions across Canada"
+      }, {
+        "id": "Patient.identifier:JHN.extension",
+        "path": "Patient.identifier.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "rules": "open"
+        }
+      }, {
+        "id": "Patient.identifier:JHN.extension:versionCode",
+        "path": "Patient.identifier.extension",
+        "sliceName": "versionCode",
+        "short": "Health Number Version Code",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://hl7.org/fhir/ca/core/StructureDefinition/ext-identifierversion"
+            ]
+          }
+        ]
+      }, {
+        "id": "Patient.identifier:JHN.type",
+        "path": "Patient.identifier.type",
+        "min": 1,
+        "fixedCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+              "code": "JHN"
+            }
+          ]
+        },
+        "mustSupport": true
+      }, {
+        "id": "Patient.identifier:JHN.system",
+        "path": "Patient.identifier.system",
+        "short": "A Health Number Naming System from the Canadian URI Registry",
+        "min": 1
+      }, {
+        "id": "Patient.identifier:JHN.value",
+        "path": "Patient.identifier.value",
+        "min": 1
+      }, {
+        "id": "Patient.name",
+        "path": "Patient.name",
+        "min": 0,
+        "constraint": [
+          {
+            "key": "ca-core-name",
+            "severity": "error",
+            "human": "Patient.name.given  or Patient.name.family or both SHALL be present",
+            "expression": "family.exists() or given.exists()",
+            "xpath": "f:given or f:family"
+          }
+        ],
+        "mustSupport": true
+      }, {
+        "id": "Patient.name.family",
+        "path": "Patient.name.family"
+      }, {
+        "id": "Patient.name.given",
+        "path": "Patient.name.given"
+      }, {
+        "id": "Patient.telecom",
+        "path": "Patient.telecom",
+        "mustSupport": true
+      }, {
+        "id": "Patient.telecom.system",
+        "path": "Patient.telecom.system",
+        "min": 1
+      }, {
+        "id": "Patient.telecom.value",
+        "path": "Patient.telecom.value",
+        "min": 1
+      }, {
+        "id": "Patient.birthDate",
+        "path": "Patient.birthDate",
+        "mustSupport": true
+      }, {
+        "id": "Patient.address",
+        "path": "Patient.address"
+      }, {
+        "id": "Patient.address.extension",
+        "path": "Patient.address.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "rules": "open"
+        }
+      }, {
+        "id": "Patient.address.extension:preferred",
+        "path": "Patient.address.extension",
+        "sliceName": "preferred",
+        "short": "HL7 Preferred Address Flag extension",
+        "definition": "Flag denoting whether parent address item is preferred",
+        "min": 0,
+        "max": "1",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://hl7.org/fhir/StructureDefinition/iso21090-preferred"
+            ]
+          }
+        ]
+      }, {
+        "id": "Patient.address.extension:no-fixed-address",
+        "path": "Patient.address.extension",
+        "sliceName": "noFixedAddress",
+        "short": "No Fixed Address indicator",
+        "definition": "Flag indicating that there is an assertion that there is no fixed address",
+        "min": 0,
+        "max": "1",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://hl7.org/fhir/ca/core/StructureDefinition/ext-nofixedaddress"
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/src/resources/structuredefinition-profile-patient.json
+++ b/src/resources/structuredefinition-profile-patient.json
@@ -1,396 +1,338 @@
 {
-  "resourceType": "StructureDefinition",
-  "id": "profile-patient",
-  "url": "http://hl7.org/fhir/ca/core/StructureDefinition/profile-patient",
-  "version": "0.1.0",
-  "name": "PatientProfile",
-  "title": "Patient Profile",
-  "status": "draft",
-  "date": "2020-01-07",
-  "publisher": "Canada Health Infoway",
-  "description": "Proposed constraints and extensions on the Patient Resource",
-  "kind": "resource",
-  "abstract": false,
-  "type": "Patient",
-  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
-  "derivation": "constraint",
-  "differential": {
-    "element": [
-      {
-        "id": "Patient",
-        "path": "Patient",
-        "short": "Patient Profile",
-        "definition": "The Patient Profile is based upon the core FHIR Patient Resource",
-        "mustSupport": true,
-        "isModifier": false
-      },
-      {
-        "id": "Patient.extension",
-        "path": "Patient.extension",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "url"
-            }
-          ],
-          "rules": "open"
-        }
-      },
-      {
-        "id": "Patient.extension:birthsex",
-        "path": "Patient.extension",
-        "sliceName": "birthsex",
-        "short": "Extension: Sex at Birth",
-        "definition": "A code classifying the person's sex assigned at birth  as specified by the [TODO: assigning authority]. This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9)",
-        "min": 0,
-        "max": "1",
-        "type": [
-          {
-            "code": "Extension",
-            "profile": [
-              "http://hl7.org/fhir/ca/core/StructureDefinition/ext-patientbirthsex"
-            ]
-          }
-        ],
-        "mustSupport": false
-      },
-      {
-        "id": "Patient.extension:ethnicity",
-        "path": "Patient.extension",
-        "sliceName": "ethnicity",
-        "short": "Extension: ethnicity extension",
-        "definition": "A code classifying the person's ethnic group or ethnicity as the category of people who identify with each other, usually on the basis of a presumed common genealogy or ancestry or on other similarities.",
-        "comment": "This attribute is based on the belief of the person or the person reporting the attribute, not on any formal analysis of genetic, geneological or historical relationships as these would need to be captured as observations.",
-        "min": 0,
-        "max": "1",
-        "type": [
-          {
-            "code": "Extension",
-            "profile": [
-              "http://hl7.org/fhir/ca/core/StructureDefinition/ext-ethnicity"
-            ]
-          }
-        ],
-        "mustSupport": false,
-        "isModifier": false,
-        "mapping": [
-          {
-            "identity": "HL7v2",
-            "map": "PID.22 [Ethnic Group]",
-            "comment": "This field further defines the patient's ancestry.  Refer to User-defined Table 0189 - Ethnic Group in Chapter 2C, Code Tables, for suggested values."
-          },
-          {
-            "identity": "rim",
-            "map": "Person.ethnicGroupCode",
-            "comment": "A code classifying the person into a named category of humans sharing a common real or presumed heritage"
-          },
-          {
-            "identity": "CDA",
-            "map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:ethnicGroupCode",
-            "comment": "This CDA R2 SDTC ethnicGroupCode extension is used to record additional ethnicity groups for the recordTarget or subjectPerson"
-          }
-        ]
-      },
-      {
-        "id": "Patient.identifier",
-        "path": "Patient.identifier",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "pattern",
-              "path": "type"
-            }
-          ],
-          "rules": "open"
-        },
-        "min": 0
-      },
-      {
-        "id": "Patient.identifier.type",
-        "path": "Patient.identifier.type",
-        "min": 1,
-        "example": [
-          {
-            "label": "Pattern",
-            "valueCodeableConcept": {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-                  "code": "MR"
-                }
-              ]
-            }
-          }
-        ],
-        "mustSupport": true
-      },
-      {
-        "id": "Patient.identifier.system",
-        "path": "Patient.identifier.system",
-        "min": 1,
-        "mustSupport": true,
-        "isModifier": false
-      },
-      {
-        "id": "Patient.identifier.value",
-        "path": "Patient.identifier.value",
-        "short": "The value that is unique within the system.",
-        "min": 1,
-        "mustSupport": true,
-        "isModifier": false
-      },
-      {
-        "id": "Patient.identifier:PPN",
-        "path": "Patient.identifier",
-        "sliceName": "PPN",
-        "short": "Canada Passport Number",
-        "mustSupport": false
-      },
-      {
-        "id": "Patient.identifier:PPN.type",
-        "path": "Patient.identifier.type",
-        "short": "Passport number identifier type",
-        "min": 1,
-        "max": "1",
-        "fixedCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-              "code": "PPN"
-            }
-          ]
-        }
-      },
-      {
-        "id": "Patient.identifier:PPN.system",
-        "path": "Patient.identifier.system",
-        "short": "A Canadian passport number Naming System from the Canadian URI Registry",
-        "min": 1,
-        "max": "1",
-        "fixedUri": "https://fhir.infoway-inforoute.ca/NamingSystem/ca-passport-number"
-      },
-      {
-        "id": "Patient.identifier:PPN.value",
-        "path": "Patient.identifier.value",
-        "short": "A Canadian passport number",
-        "min": 1,
-        "max": "1"
-      },
-      {
-        "id": "Patient.identifier:JPID",
-        "path": "Patient.identifier",
-        "sliceName": "JPID",
-        "short": "Jurisdictional Person Identification",
-        "definition": "Federal patient and person identifiers used by all jurisdictions across Canada",
-        "mustSupport": false
-      },
-      {
-        "id": "Patient.identifier:JPID.type",
-        "path": "Patient.identifier.type",
-        "short": "Jurisdictional Person Identification",
-        "min": 1,
-        "max": "1",
-        "fixedCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-              "code": "JPID"
-            }
-          ]
-        }
-      },
-      {
-        "id": "Patient.identifier:JPID.system",
-        "path": "Patient.identifier.system",
-        "short": "Jurisdictional Person identification Naming System from the Canadian URI Registry",
-        "min": 1,
-        "max": "1",
-        "example": [
-          {
-            "label": "Canada, Social Insurance Number system URI",
-            "valueUri": "https://fhir.infoway-inforoute.ca/NamingSystem/ca-social-insurance-number"
-          }
-        ]
-      },
-      {
-        "id": "Patient.identifier:JPID.value",
-        "path": "Patient.identifier.value",
-        "short": "Jurisdictional Person identification number",
-        "min": 1,
-        "max": "1",
-        "example": [
-          {
-            "label": "Canada, Social Insurance Number (SIN)",
-            "valueString": "924123456"
-          }
-        ]
-      },
-      {
-        "id": "Patient.identifier:JHN",
-        "path": "Patient.identifier",
-        "sliceName": "JHN",
-        "short": "Jurisdictional Health Number",
-        "definition": "Federal patient and person health numbers used by all jurisdictions across Canada"
-      },
-      {
-        "id": "Patient.identifier:JHN.extension",
-        "path": "Patient.identifier.extension",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "url"
-            }
-          ],
-          "rules": "open"
-        }
-      },
-      {
-        "id": "Patient.identifier:JHN.extension:versionCode",
-        "path": "Patient.identifier.extension",
-        "sliceName": "versionCode",
-        "short": "Health Number Version Code",
-        "type": [
-          {
-            "code": "Extension",
-            "profile": [
-              "http://hl7.org/fhir/ca/core/StructureDefinition/ext-identifierversion"
-            ]
-          }
-        ]
-      },
-      {
-        "id": "Patient.identifier:JHN.type",
-        "path": "Patient.identifier.type",
-        "min": 1,
-        "fixedCodeableConcept": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
-              "code": "JHN"
-            }
-          ]
-        },
-        "mustSupport": true
-      },
-      {
-        "id": "Patient.identifier:JHN.system",
-        "path": "Patient.identifier.system",
-        "short": "A Health Number Naming System from the Canadian URI Registry",
-        "min": 1,
-        "example": [
-          {
-            "label": "Canada Armed Forces health card number system URI",
-            "valueUri": "https://fhir.infoway-inforoute.ca/NamingSystem/ca-armed-forces-health-id"
-          }
-        ]
-      },
-      {
-        "id": "Patient.identifier:JHN.value",
-        "path": "Patient.identifier.value",
-        "min": 1,
-        "example": [
-          {
-            "label": "Canada Armed Forces health card number",
-            "valueString": "A91234569"
-          }
-        ]
-      },
-      {
-        "id": "Patient.name",
-        "path": "Patient.name",
-        "min": 1,
-        "constraint": [
-          {
-            "key": "ca-core-name",
-            "severity": "error",
-            "human": "Patient.name.given  or Patient.name.family or both SHALL be present",
-            "expression": "family.exists() or given.exists()",
-            "xpath": "f:given or f:family"
-          }
-        ],
-        "mustSupport": true
-      },
-      {
-        "id": "Patient.name.family",
-        "path": "Patient.name.family"
-      },
-      {
-        "id": "Patient.name.given",
-        "path": "Patient.name.given"
-      },
-      {
-        "id": "Patient.telecom",
-        "path": "Patient.telecom",
-        "mustSupport": true
-      },
-      {
-        "id": "Patient.telecom.system",
-        "path": "Patient.telecom.system",
-        "min": 1
-      },
-      {
-        "id": "Patient.telecom.value",
-        "path": "Patient.telecom.value",
-        "min": 1
-      },
-      {
-        "id": "Patient.birthDate",
-        "path": "Patient.birthDate",
-        "mustSupport": true
-      },
-      {
-        "id": "Patient.address",
-        "path": "Patient.address"
-      },
-      {
-        "id": "Patient.address.extension",
-        "path": "Patient.address.extension",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "url"
-            }
-          ],
-          "rules": "open"
-        }
-      },
-      {
-        "id": "Patient.address.extension:preferred",
-        "path": "Patient.address.extension",
-        "sliceName": "preferred",
-        "short": "HL7 Preferred Address Flag extension",
-        "definition": "Flag denoting whether parent address item is preferred",
-        "min": 0,
-        "max": "1",
-        "type": [
-          {
-            "code": "Extension",
-            "profile": [
-              "http://hl7.org/fhir/StructureDefinition/iso21090-preferred"
-            ]
-          }
-        ]
-      },
-      {
-        "id": "Patient.address.extension:no-fixed-address",
-        "path": "Patient.address.extension",
-        "sliceName": "noFixedAddress",
-        "short": "No Fixed Address indicator",
-        "definition": "Flag indicating that there is an assertion that there is no fixed address",
-        "min": 0,
-        "max": "1",
-        "type": [
-          {
-            "code": "Extension",
-            "profile": [
-              "http://hl7.org/fhir/ca/core/StructureDefinition/ext-nofixedaddress"
-            ]
-          }
-        ]
-      }
-    ]
-  }
+	"resourceType": "StructureDefinition",
+	"id": "profile-patient",
+	"url": "http://hl7.org/fhir/ca/core/StructureDefinition/profile-patient",
+	"version": "0.1.0",
+	"name": "PatientProfile",
+	"title": "Patient Profile",
+	"status": "draft",
+	"date": "2020-01-13",
+	"publisher": "Canada Health Infoway",
+	"description": "Proposed constraints and extensions on the Patient Resource",
+	"kind": "resource",
+	"abstract": false,
+	"type": "Patient",
+	"baseDefinition": "http://hl7.org/fhir/StructureDefinition/Patient",
+	"derivation": "constraint",
+	"differential": {
+		"element": [
+			{
+				"id": "Patient",
+				"path": "Patient",
+				"short": "Patient Profile",
+				"definition": "The Patient Profile is based upon the core FHIR Patient Resource",
+				"mustSupport": true,
+				"isModifier": false
+			}, {
+				"id": "Patient.extension",
+				"path": "Patient.extension",
+				"slicing": {
+					"discriminator": [
+						{
+							"type": "value",
+							"path": "url"
+						}
+					],
+					"rules": "open"
+				}
+			}, {
+				"id": "Patient.extension:birthsex",
+				"path": "Patient.extension",
+				"sliceName": "birthsex",
+				"short": "Extension: Sex at Birth",
+				"definition": "A code classifying the person's sex assigned at birth  as specified by the [TODO: assigning authority]. This extension aligns with the C-CDA Birth Sex Observation (LOINC 76689-9)",
+				"min": 0,
+				"max": "1",
+				"type": [
+					{
+						"code": "Extension",
+						"profile": [
+							"http://hl7.org/fhir/ca/core/StructureDefinition/ext-patientbirthsex"
+						]
+					}
+				],
+				"mustSupport": false
+			}, {
+				"id": "Patient.extension:ethnicity",
+				"path": "Patient.extension",
+				"sliceName": "ethnicity",
+				"short": "Extension: ethnicity extension",
+				"definition": "A code classifying the person's ethnic group or ethnicity as the category of people who identify with each other, usually on the basis of a presumed common genealogy or ancestry or on other similarities.",
+				"comment": "This attribute is based on the belief of the person or the person reporting the attribute, not on any formal analysis of genetic, geneological or historical relationships as these would need to be captured as observations.",
+				"min": 0,
+				"max": "1",
+				"type": [
+					{
+						"code": "Extension",
+						"profile": [
+							"http://hl7.org/fhir/ca/core/StructureDefinition/ext-ethnicity"
+						]
+					}
+				],
+				"mustSupport": false,
+				"isModifier": false,
+				"mapping": [
+					{
+						"identity": "HL7v2",
+						"map": "PID.22 [Ethnic Group]",
+						"comment": "This field further defines the patient's ancestry.  Refer to User-defined Table 0189 - Ethnic Group in Chapter 2C, Code Tables, for suggested values."
+					}, {
+						"identity": "rim",
+						"map": "Person.ethnicGroupCode",
+						"comment": "A code classifying the person into a named category of humans sharing a common real or presumed heritage"
+					}, {
+						"identity": "CDA",
+						"map": "/ClinicalDocument/recordTarget/patientRole/patient/sdtc:ethnicGroupCode",
+						"comment": "This CDA R2 SDTC ethnicGroupCode extension is used to record additional ethnicity groups for the recordTarget or subjectPerson"
+					}
+				]
+			}, {
+				"id": "Patient.identifier",
+				"path": "Patient.identifier",
+				"slicing": {
+					"discriminator": [
+						{
+							"type": "pattern",
+							"path": "type"
+						}
+					],
+					"rules": "open"
+				},
+				"min": 0
+			}, {
+				"id": "Patient.identifier.type",
+				"path": "Patient.identifier.type",
+				"min": 1,
+				"example": [
+					{
+						"label": "Pattern",
+						"valueCodeableConcept": {
+							"coding": [
+								{
+									"system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+									"code": "MR"
+								}
+							]
+						}
+					}
+				],
+				"mustSupport": true
+			}, {
+				"id": "Patient.identifier.system",
+				"path": "Patient.identifier.system",
+				"min": 1,
+				"mustSupport": true,
+				"isModifier": false
+			}, {
+				"id": "Patient.identifier.value",
+				"path": "Patient.identifier.value",
+				"short": "The value that is unique within the system.",
+				"min": 1,
+				"mustSupport": true,
+				"isModifier": false
+			}, {
+				"id": "Patient.identifier:PPN",
+				"path": "Patient.identifier",
+				"sliceName": "PPN",
+				"short": "Canada Passport Number",
+				"mustSupport": false
+			}, {
+				"id": "Patient.identifier:PPN.type",
+				"path": "Patient.identifier.type",
+				"short": "Passport number identifier type",
+				"min": 1,
+				"max": "1",
+				"fixedCodeableConcept": {
+					"coding": [
+						{
+							"system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+							"code": "PPN"
+						}
+					]
+				}
+			}, {
+				"id": "Patient.identifier:PPN.system",
+				"path": "Patient.identifier.system",
+				"short": "A Canadian passport number Naming System from the Canadian URI Registry",
+				"min": 1,
+				"max": "1",
+				"fixedUri": "https://fhir.infoway-inforoute.ca/NamingSystem/ca-passport-number"
+			}, {
+				"id": "Patient.identifier:PPN.value",
+				"path": "Patient.identifier.value",
+				"short": "A Canadian passport number",
+				"min": 1,
+				"max": "1"
+			}, {
+				"id": "Patient.identifier:JPID",
+				"path": "Patient.identifier",
+				"sliceName": "JPID",
+				"short": "Jurisdictional Person Identification",
+				"definition": "Federal patient and person identifiers used by all jurisdictions across Canada",
+				"mustSupport": false
+			}, {
+				"id": "Patient.identifier:JPID.type",
+				"path": "Patient.identifier.type",
+				"short": "Jurisdictional Person Identification",
+				"min": 1,
+				"max": "1",
+				"fixedCodeableConcept": {
+					"coding": [
+						{
+							"system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+							"code": "JPID"
+						}
+					]
+				}
+			}, {
+				"id": "Patient.identifier:JPID.system",
+				"path": "Patient.identifier.system",
+				"short": "Jurisdictional Person identification Naming System from the Canadian URI Registry",
+				"min": 1,
+				"max": "1"
+			}, {
+				"id": "Patient.identifier:JPID.value",
+				"path": "Patient.identifier.value",
+				"short": "Jurisdictional Person identification number",
+				"min": 1,
+				"max": "1"
+			}, {
+				"id": "Patient.identifier:JHN",
+				"path": "Patient.identifier",
+				"sliceName": "JHN",
+				"short": "Jurisdictional Health Number",
+				"definition": "Federal patient and person health numbers used by all jurisdictions across Canada"
+			}, {
+				"id": "Patient.identifier:JHN.extension",
+				"path": "Patient.identifier.extension",
+				"slicing": {
+					"discriminator": [
+						{
+							"type": "value",
+							"path": "url"
+						}
+					],
+					"rules": "open"
+				}
+			}, {
+				"id": "Patient.identifier:JHN.extension:versionCode",
+				"path": "Patient.identifier.extension",
+				"sliceName": "versionCode",
+				"short": "Health Number Version Code",
+				"type": [
+					{
+						"code": "Extension",
+						"profile": [
+							"http://hl7.org/fhir/ca/core/StructureDefinition/ext-identifierversion"
+						]
+					}
+				]
+			}, {
+				"id": "Patient.identifier:JHN.type",
+				"path": "Patient.identifier.type",
+				"min": 1,
+				"fixedCodeableConcept": {
+					"coding": [
+						{
+							"system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+							"code": "JHN"
+						}
+					]
+				},
+				"mustSupport": true
+			}, {
+				"id": "Patient.identifier:JHN.system",
+				"path": "Patient.identifier.system",
+				"short": "A Health Number Naming System from the Canadian URI Registry",
+				"min": 1
+			}, {
+				"id": "Patient.identifier:JHN.value",
+				"path": "Patient.identifier.value",
+				"min": 1
+			}, {
+				"id": "Patient.name",
+				"path": "Patient.name",
+				"min": 0,
+				"constraint": [
+					{
+						"key": "ca-core-name",
+						"severity": "error",
+						"human": "Patient.name.given  or Patient.name.family or both SHALL be present",
+						"expression": "family.exists() or given.exists()",
+						"xpath": "f:given or f:family"
+					}
+				],
+				"mustSupport": true
+			}, {
+				"id": "Patient.name.family",
+				"path": "Patient.name.family"
+			}, {
+				"id": "Patient.name.given",
+				"path": "Patient.name.given"
+			}, {
+				"id": "Patient.telecom",
+				"path": "Patient.telecom",
+				"mustSupport": true
+			}, {
+				"id": "Patient.telecom.system",
+				"path": "Patient.telecom.system",
+				"min": 1
+			}, {
+				"id": "Patient.telecom.value",
+				"path": "Patient.telecom.value",
+				"min": 1
+			}, {
+				"id": "Patient.birthDate",
+				"path": "Patient.birthDate",
+				"mustSupport": true
+			}, {
+				"id": "Patient.address",
+				"path": "Patient.address"
+			}, {
+				"id": "Patient.address.extension",
+				"path": "Patient.address.extension",
+				"slicing": {
+					"discriminator": [
+						{
+							"type": "value",
+							"path": "url"
+						}
+					],
+					"rules": "open"
+				}
+			}, {
+				"id": "Patient.address.extension:preferred",
+				"path": "Patient.address.extension",
+				"sliceName": "preferred",
+				"short": "HL7 Preferred Address Flag extension",
+				"definition": "Flag denoting whether parent address item is preferred",
+				"min": 0,
+				"max": "1",
+				"type": [
+					{
+						"code": "Extension",
+						"profile": [
+							"http://hl7.org/fhir/StructureDefinition/iso21090-preferred"
+						]
+					}
+				]
+			}, {
+				"id": "Patient.address.extension:no-fixed-address",
+				"path": "Patient.address.extension",
+				"sliceName": "noFixedAddress",
+				"short": "No Fixed Address indicator",
+				"definition": "Flag indicating that there is an assertion that there is no fixed address",
+				"min": 0,
+				"max": "1",
+				"type": [
+					{
+						"code": "Extension",
+						"profile": [
+							"http://hl7.org/fhir/ca/core/StructureDefinition/ext-nofixedaddress"
+						]
+					}
+				]
+			}
+		]
+	}
 }


### PR DESCRIPTION
1) Framework change to move the Terminology Bindings and Constraints sections after the notes section.  (See issue #98 for rationale.)  Implemented by substream, tested (ok) on this branch.